### PR TITLE
Add ffmpeg-based RTSP snapshot service for n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-Capture frame from RTSP and use it in N8N
+# Capture frame from RTSP and use it in n8n
+
+This repository contains a tiny Node.js HTTP service that relies on `ffmpeg` to grab a single frame from an RTSP stream. The service is designed to be run alongside n8n so that you can trigger snapshot capture from a workflow using the HTTP Request node (or any other trigger you prefer).
+
+## Prerequisites
+
+- Node.js 18 or newer
+- `ffmpeg` available on the machine where n8n runs
+- An RTSP URL exposed by your camera (e.g. `rtsp://user:pass@ip-address:554/stream`)
+
+## Installation
+
+```bash
+# Clone the repository and move inside it
+npm install
+```
+
+No additional dependencies are required because the service uses Node's built-in modules and shelling out to `ffmpeg`.
+
+## Configuration
+
+The service reads configuration from environment variables:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `RTSP_URL` | **Required.** Full RTSP URL to your camera stream. | — |
+| `PORT` | HTTP port for the snapshot server. | `8080` |
+| `FFMPEG_BIN` | Path to the `ffmpeg` binary if it is not in `PATH`. | `ffmpeg` |
+
+You can set them inline when starting the service or using an `.env` manager of your choice.
+
+## Usage
+
+Start the server:
+
+```bash
+RTSP_URL="rtsp://user:pass@camera/stream" npm start
+```
+
+Once the server is running, you can request snapshots:
+
+- `GET /snapshot` (or `GET /`) returns JSON with a base64-encoded image.
+- `GET /snapshot?response=binary` streams the raw image with the correct content-type header.
+- Optional query parameters:
+  - `codec=png` (default is `mjpeg` → JPEG output).
+  - `timeout_ms=15000` to change the capture timeout (default 10 seconds).
+
+### Example cURL
+
+```bash
+curl "http://localhost:8080/snapshot" \
+  | jq -r '.data' \
+  | base64 --decode \
+  > snapshot.jpg
+```
+
+```bash
+curl -o snapshot.jpg "http://localhost:8080/snapshot?response=binary"
+```
+
+## Integrating with n8n
+
+1. **Create a new workflow** and add a trigger (Cron, Webhook, or Manual trigger).
+2. **Add an HTTP Request node** configured as follows:
+   - Method: `GET`
+   - URL: `http://localhost:8080/snapshot?response=binary`
+   - Response: set `Response Format` to `File` so the binary payload is passed along.
+3. Optionally follow with a **Move Binary Data** or **Function** node to convert the binary to base64 or store it.
+4. Continue your workflow (send to Telegram/Email, store in S3, run OpenCV processing, etc.).
+
+For periodic snapshots, combine the Cron trigger with the HTTP Request node. For event-driven snapshots, use a Webhook trigger or any other node that leads to the HTTP Request node.
+
+## Running as a background service
+
+For long-running usage on the same host as n8n, consider using `pm2`, `systemd`, or Docker to keep the service alive. A simple systemd unit could look like:
+
+```ini
+[Unit]
+Description=RTSP snapshot service for n8n
+After=network.target
+
+[Service]
+Environment=RTSP_URL=rtsp://user:pass@camera/stream
+WorkingDirectory=/opt/n8n-rtsp-snapshot
+ExecStart=/usr/bin/npm start
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Adjust the paths and environment variables as needed for your setup.
+
+## Troubleshooting
+
+- If you see timeouts, check network connectivity to the camera and try increasing `timeout_ms`.
+- Use `FFMPEG_BIN` if `ffmpeg` is installed in a non-standard location.
+- Review logs printed by the service to diagnose `ffmpeg` errors (wrong URL, authentication issues, unsupported codec, etc.).
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "n8n-rtsp-snapshot-service",
+  "version": "0.1.0",
+  "description": "Minimal HTTP service that captures frames from an RTSP stream using ffmpeg for n8n",
+  "main": "src/snapshot-server.js",
+  "bin": {
+    "rtsp-snapshot-server": "src/snapshot-server.js"
+  },
+  "scripts": {
+    "start": "node src/snapshot-server.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/src/snapshot-server.js
+++ b/src/snapshot-server.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Minimal HTTP server that captures a single frame from an RTSP stream
+ * using ffmpeg and returns it either as base64-encoded JSON or as binary.
+ */
+const http = require('http');
+const { spawn } = require('child_process');
+const { URL } = require('url');
+
+const PORT = Number(process.env.PORT || 8080);
+const RTSP_URL = process.env.RTSP_URL;
+const FFMPEG_BIN = process.env.FFMPEG_BIN || 'ffmpeg';
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+if (!RTSP_URL) {
+  console.error('Environment variable RTSP_URL must be set.');
+  process.exit(1);
+}
+
+function captureFrame({ timeoutMs = DEFAULT_TIMEOUT_MS, imageCodec = 'mjpeg' } = {}) {
+  return new Promise((resolve, reject) => {
+    const ffmpegArgs = [
+      '-rtsp_transport', 'tcp',
+      '-y',
+      '-i', RTSP_URL,
+      '-frames:v', '1',
+      '-f', 'image2pipe',
+      '-vcodec', imageCodec,
+      'pipe:1',
+    ];
+
+    const child = spawn(FFMPEG_BIN, ffmpegArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`Timeout after ${timeoutMs} ms`));
+    }, timeoutMs);
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(Buffer.concat(stdoutChunks));
+      } else {
+        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        reject(new Error(`ffmpeg exited with code ${code}: ${stderr}`));
+      }
+    });
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method !== 'GET') {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Only GET is supported' }));
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname !== '/' && url.pathname !== '/snapshot') {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  const responseType = url.searchParams.get('response') || 'base64';
+  const codec = url.searchParams.get('codec') || 'mjpeg';
+  const timeout = Number(url.searchParams.get('timeout_ms') || DEFAULT_TIMEOUT_MS);
+
+  try {
+    const imageBuffer = await captureFrame({ timeoutMs: timeout, imageCodec: codec });
+
+    if (responseType === 'binary') {
+      res.writeHead(200, {
+        'Content-Type': codec === 'png' ? 'image/png' : 'image/jpeg',
+        'Content-Length': imageBuffer.length,
+        'Cache-Control': 'no-store',
+      });
+      res.end(imageBuffer);
+      return;
+    }
+
+    const base64 = imageBuffer.toString('base64');
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+    res.end(JSON.stringify({
+      format: codec === 'png' ? 'png' : 'jpeg',
+      size: imageBuffer.length,
+      data: base64,
+    }));
+  } catch (error) {
+    console.error(error);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: error.message }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Snapshot server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a minimal Node.js HTTP service that captures RTSP frames using ffmpeg for consumption by n8n workflows
- document configuration, usage patterns, and integration guidance in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e17732d2c8832a9fd43509165e2b08